### PR TITLE
Get access key from config instead of env so configs can be cached

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ Once you have done that, add the following line, containing your key, to your `.
 UNSPLASH_ACCESS_KEY=<your access key>
 ```
 
+Then add your access key to the `config/services.php` file:
+
+```php
+return [
+    // ...
+
+    'unsplash' => [
+        'access_key' => env('UNSPLASH_ACCESS_KEY')
+    ],
+
+];
+```
+
 ### Usage
 
 **Before using the field it will be necessary to add a column to your table.**

--- a/src/Unsplash.php
+++ b/src/Unsplash.php
@@ -51,7 +51,7 @@ class Unsplash extends Field
         parent::__construct($name, $attribute, $resolveCallback);
 
         $this->withMeta([
-            'unsplashKey' => env('UNSPLASH_ACCESS_KEY', ''),
+            'unsplashKey' => config('services.unsplash.access_key'),
             'queryPlaceholder' => $this->queryPlaceholder,
             'orientation' => $this->orientation,
             'featured' => $this->featured,


### PR DESCRIPTION
Currently, the package fetches the access key directly from the `.env` file.
When caching the configs using `php artisan config:cache`, the `env` function will return null for any key.
Therefore, it's best practice to use `env` variables only in config files and use those config files in the application code.

This PR does 2 things:

- Fetches the access key from the `config/services.php` file.
- Adds instructions on how to add the access key to the `config/services.php` file so the field can fetch it from the correct location.